### PR TITLE
[Peer Review] - The images will overlap with text on windows resize.

### DIFF
--- a/front/src/asset/style/DisplayPage.css
+++ b/front/src/asset/style/DisplayPage.css
@@ -18,6 +18,7 @@
   margin: 10px;
 }
 
+/* Make .post-card-img responsive to prevent overlap with text on window resize */
 .post-card-img {
   max-width: 400px;
 }


### PR DESCRIPTION
Make .post-card-img responsive to prevent overlap with text on window resize