### PR TITLE
add link to deal titles

### DIFF
--- a/front/src/pages/DisplayPage.jsx
+++ b/front/src/pages/DisplayPage.jsx
@@ -55,6 +55,8 @@ export function DisplayPage({ category }) {
                   />
                 </div>
                 <div className="col-md-8 text-center">
+                  // Code: Reviewer: I would suggest making it so that clicking the
+                  // the name  <h3> tag also redirects you to "/deals/id/${post._id}"
                   <h3>{post.title}</h3>
                   <p>Likes: {post.like}</p>
                   <p className="post-content">{post.description}</p>


### PR DESCRIPTION
It would make it more intuitive to navigate if the title of the cards also redirected to the details page. 